### PR TITLE
feat: use performance.now

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,13 +1,15 @@
 const Stats = require("./stats");
 
+const performance = (typeof window === "object" && "performance" in window) ? window.performance : require("perf_hooks").performance
+
 async function runTest(callback, iterations) {
   let stats = new Stats();
 
   for (let i = 0; i < iterations; i++) {
-    let start = process.hrtime();
+    const start = performance.now();
     await callback();
-    let took = process.hrtime(start);
-    stats.add(took[0] * 1e9 + took[1]);
+    const end = performance.now();
+    stats.add(end - start);
   }
 
   return stats;

--- a/stats.js
+++ b/stats.js
@@ -3,7 +3,7 @@ const round = (val, points = 3) => {
 };
 
 const formatTime = val => {
-  let res = val;
+  let res = val * 1e6;
 
   if (res < 1000) {
     return `${round(res)}ns`;
@@ -48,7 +48,7 @@ module.exports = class Stats {
   }
 
   opsPerSec() {
-    return 1e9 / this.mean();
+    return 1e3 / this.mean();
   }
 
   toString() {


### PR DESCRIPTION
Fixes #3 

The number of operations is correct as the unit of `performance.now` is `ms`.

